### PR TITLE
Rewritten add_default_gateway to use the rtnetlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ ERL_EI_LIBDIR ?= $(ERL_PATH)/usr/lib
 ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
 
 LDFLAGS += -lmnl
+LDFLAGS += -lnetlink
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 
 


### PR DESCRIPTION
Please do NOT merge yet - under test -
alternative implementation of the default gateway addition using the rtnetlink interface analogous to what 'ip rout add default <ip address> dev eth0' does