### PR TITLE
Devel/small refactor

### DIFF
--- a/lib/network_interface/worker.ex
+++ b/lib/network_interface/worker.ex
@@ -197,9 +197,9 @@ defmodule Nerves.NetworkInterface.Worker do
     end)
   end
 
-  def handle_info({_, {:data, <<?n, message::binary>>}}, state) do
+  def handle_info({_, input = {:data, <<?n, message::binary>>}}, state) do
     try do
-      {notif, data} = :erlang.binary_to_term(message, [:safe])
+      {notif, data} = :erlang.binary_to_term(message)
       dispatch(notif, data)
     rescue
       e -> Logger.error("Error converting to term: #{inspect e}!")
@@ -225,7 +225,7 @@ defmodule Nerves.NetworkInterface.Worker do
     msg = {command, arguments}
     send state.port, {self(), {:command, :erlang.term_to_binary(msg)}}
     receive do
-      {_, {:data, <<?r, response::binary>>}} ->
+      {_, {:data, bs = <<?r, response::binary>>}} ->
         :erlang.binary_to_term(response)
     after
       4_000 ->

--- a/lib/network_interface/worker.ex
+++ b/lib/network_interface/worker.ex
@@ -197,7 +197,7 @@ defmodule Nerves.NetworkInterface.Worker do
     end)
   end
 
-  def handle_info({_, input = {:data, <<?n, message::binary>>}}, state) do
+  def handle_info({_, _input = {:data, <<?n, message::binary>>}}, state) do
     try do
       {notif, data} = :erlang.binary_to_term(message)
       dispatch(notif, data)

--- a/lib/network_interface/worker.ex
+++ b/lib/network_interface/worker.ex
@@ -225,7 +225,7 @@ defmodule Nerves.NetworkInterface.Worker do
     msg = {command, arguments}
     send state.port, {self(), {:command, :erlang.term_to_binary(msg)}}
     receive do
-      {_, {:data, bs = <<?r, response::binary>>}} ->
+      {_, {:data, <<?r, response::binary>>}} ->
         :erlang.binary_to_term(response)
     after
       4_000 ->

--- a/mix.lock
+++ b/mix.lock
@@ -3,5 +3,5 @@
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm", "3b1dcad3067985dd8618c38399a8ee9c4e652d52a17a4aae7a6d6fc4fcc24856"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "f050061c87ad39478c942995b5a20c40f2c0bc06525404613b8b0474cb8bd796"},
-  "muontrap": {:hex, :muontrap, "0.6.1", "fa11dc9152470c4d0ce5a5fcb6524d8c1edc9bf6d63b3f6a89096f1e751ae271", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "86d1ef2fa0a30435a1d595e96f631ad4a24a931d8d855688e012fadd7147bd1d"},
+  "muontrap": {:hex, :muontrap, "1.0.0", "53a05c37f71cc5070aaa0858a774ae1f500160b7186a70565521a14ef7843c5a", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "0d3cd6e335986f9c2af1b61f583375b0f0d91cea95b7ec7bc720f330b4dc9b49"},
 }

--- a/src/netif.c
+++ b/src/netif.c
@@ -290,7 +290,6 @@ static int netif_build_ifinfo(const struct nlmsghdr *nlh, void *data)
 
     int count = 8; /* Number of fields that we always encode */
     int i;
-    int encoded_item = 0;
 
     for (i = 0; i <= IFLA_MAX; i++)
         if (tb[i])
@@ -549,7 +548,7 @@ static void netif_set_ifflags(struct netif *nb,
 
     start_response(nb);
 
-    memcpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
     if (ioctl(nb->inet_fd, SIOCGIFFLAGS, &ifr) < 0) {
         debug("SIOCGIFFLAGS error: %s", strerror(errno));
         erlcmd_encode_errno_error(nb->resp, &nb->resp_index, errno);
@@ -1292,7 +1291,7 @@ static int set_mac_address_ioctl(const struct ip_setting_handler *handler, struc
 
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    memcpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
 
     struct sockaddr_in *addr = (struct sockaddr_in *) &ifr.ifr_addr;
     addr->sin_family = AF_UNIX;
@@ -1316,7 +1315,7 @@ static int get_mac_address_ioctl(const struct ip_setting_handler *handler, struc
 {
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    memcpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
 
     if (ioctl(nb->inet_fd, handler->ioctl_get, &ifr) < 0) {
         debug("ioctl(0x%04x) failed for getting '%s': %s", handler->ioctl_get, handler->name, strerror(errno));
@@ -1337,7 +1336,7 @@ static int get_mac_address_ioctl(const struct ip_setting_handler *handler, struc
 
 static int prep_ipaddr_ioctl(const struct ip_setting_handler *handler, struct netif *nb, void **context)
 {
-    char ipaddr[INET_ADDRSTRLEN];
+    char ipaddr[INET_ADDRSTRLEN] = {'\0', };
     if (erlcmd_decode_string(nb->req, &nb->req_index, ipaddr, INET_ADDRSTRLEN) < 0)
         errx(EXIT_FAILURE, "ip address parameter required for '%s'", handler->name);
 
@@ -1355,7 +1354,7 @@ static int prep_ipaddr_ioctl(const struct ip_setting_handler *handler, struct ne
 static int prep_ipaddr(const struct ip_setting_handler *handler, struct netif *nb, void **context)
 {
     #define PREFIX_LEN  (3) /* ':' + 2 bytes i.e. 1.2.3.4:32 */
-    char ipaddr[INET_ADDRSTRLEN+PREFIX_LEN];
+    char ipaddr[INET_ADDRSTRLEN+PREFIX_LEN] = {'\0', };
     if (erlcmd_decode_string(nb->req, &nb->req_index, ipaddr, INET_ADDRSTRLEN+PREFIX_LEN) < 0)
         errx(EXIT_FAILURE, "ip address parameter required for '%s'", handler->name);
 
@@ -1377,7 +1376,7 @@ static int prep_ipaddr6_ioctl(const struct ip_setting_handler *handler, struct n
 {
     struct in6_ifreq *ifr6  = malloc(sizeof(struct in6_ifreq));
     char *prefix_ptr = (void *) NULL;
-    char ipaddr[INET6_ADDRSTRLEN] = {0, };
+    char ipaddr[INET6_ADDRSTRLEN] = {'\0', };
 
     if(ifr6 == NULL) {
         debug("Unable to allocate memory for '%s'", handler->name);
@@ -1438,7 +1437,7 @@ static int set_ipaddr_ioctl(const struct ip_setting_handler *handler, struct net
 
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    memcpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
 
     struct sockaddr_in *addr = (struct sockaddr_in *) &ifr.ifr_addr;
 


### PR DESCRIPTION
Small code improvements including and not limited to compilation warnings
The annoying %ArgumentError on :safe check of converting notification binary to term (not-yet-existent-atoms were causing it) hence subscribers were not receiving interface changed notifications at the early stage of network initialisation