### PR TITLE
Adding handlers for advertised link modes as well as enforced link mode

### DIFF
--- a/lib/nerves_network_interface.ex
+++ b/lib/nerves_network_interface.ex
@@ -149,24 +149,62 @@ defmodule Nerves.NetworkInterface do
 
   @doc """
   Return the IP configuration for the specified interface as a map. See
-  `setup/3` for options.
+  `setup/2` for options.
 
   Returns `{:ok, config}` on success or `{:error, reason}` if an error occurs.
   """
   defdelegate settings(ifname), to: Nerves.NetworkInterface.Worker
 
   @doc """
-  Set IP settings for the specified interface. The following options are
-  available:
+  Apply network configuration for the specified interface.
 
-    * `:ipv4_address` - the IPv4 address of the interface
-    * `:ipv4_broadcast` - the IPv4 broadcast address for the interface
-    * `:ipv4_subnet_mask` - the IPv4 subnet mask
-    * `:ipv4_gateway` - the default gateway
+  The `options` argument can be either a keyword list or a map.
+  Only keys included in `options` are updated.
 
-  Options can be specified either as a keyword list or as a map.
+  Common IPv4 options:
 
-  Returns `:ok` on success or `{:error, reason}` if an error occurs.
+    * `:ipv4_address` - IPv4 address of the interface
+    * `:ipv4_broadcast` - IPv4 broadcast address
+    * `:ipv4_subnet_mask` - IPv4 subnet mask
+    * `:ipv4_gateway` - default IPv4 gateway (set `""` to remove)
+
+  Common IPv6 options:
+
+    * `:ipv6_disable` - enable/disable IPv6 stack
+    * `:ipv6_autoconf` - enable/disable SLAAC/autoconfiguration
+    * `:ipv6_accept_ra` - Router Advertisement policy
+    * `:ipv6_accept_ra_pinfo` - accept RA prefix info
+    * `:ipv6_address` - IPv6 address/prefix
+    * `:ipv6_gateway` - default IPv6 gateway
+    * `:"-ipv6_address"` - remove an IPv6 address
+    * `:"-ipv6_gateway"` - remove an IPv6 gateway
+
+  Ethernet link options:
+
+    * `:advertised_link_modes` - advertised mode bitmask for auto-negotiation
+    * `:link_mode` - forced mode tuple `{speed_mbps, duplex}`
+
+  ## Notes
+
+    * 1000BASE-T operation should use auto-negotiation.
+    * Calls may return temporary busy errors during early bootstrap; callers
+      should retry with bounded backoff when appropriate.
+
+  Returns `:ok` on success, or `{:error, reason}` if the request fails.
+
+  ## Examples
+
+      iex> Nerves.NetworkInterface.setup("eth0", %{ipv4_gateway: "192.168.1.1"})
+      :ok
+
+      iex> Nerves.NetworkInterface.setup("eth0", [ipv6_disable: true])
+      :ok
+
+      iex> Nerves.NetworkInterface.setup("eth0", %{advertised_link_modes: 0x02F})
+      :ok
+
+      iex> Nerves.NetworkInterface.setup("eth0", %{link_mode: {100, :full}})
+      :ok
   """
   defdelegate setup(ifname, options), to: Nerves.NetworkInterface.Worker
 

--- a/src/erlcmd.c
+++ b/src/erlcmd.c
@@ -220,6 +220,15 @@ int erlcmd_decode_uint(const char *buf, int *index, unsigned long *value)
     }
 }
 
+int erlcmd_decode_tuple_header(const char *buf, int *index, int *arity)
+{
+    int type;
+    if (ei_get_type(buf, index, &type, arity) < 0 || type != ERL_SMALL_TUPLE_EXT)
+	return -1;
+
+    return ei_decode_tuple_header(buf, index, arity);
+}
+
 /**
  * @brief Encode the atom "ok" for the common success response.
  * @param buf where to store the atom

--- a/src/erlcmd.h
+++ b/src/erlcmd.h
@@ -50,6 +50,7 @@ void erlcmd_process(struct erlcmd *handler);
 int erlcmd_decode_string(const char *buf, int *index, char *dest, int maxlength);
 int erlcmd_decode_atom(const char *buf, int *index, char *dest, int maxlength);
 int erlcmd_decode_uint(const char *buf, int *index, unsigned long *value);
+int erlcmd_decode_tuple_header(const char *buf, int *index, int *arity);
 
 int erlcmd_encode_ok(char *buf, int *index);
 int erlcmd_encode_error_tuple(char *buf, int *index, const char *error_atom);

--- a/src/netif.c
+++ b/src/netif.c
@@ -421,6 +421,43 @@ static int ethtool_sset_advertising_ioctl(struct netif *nb, const char *ifname, 
     return 0;
 }
 
+/* Note: This function will first retrieve the current settings using ETHTOOL_GSET, then it will disable autonegotiation, set the desired speed and duplexity, and finally apply the new settings using ETHTOOL_SSET. On failure, it will log an error message and return -1, while on success it will return 0. */
+static int ethtool_sset_speed_duplexity_ioctl(struct netif *nb, const char *ifname, const __u32 speed, const __u8 duplex)
+{
+    struct ethtool_cmd ecmd = {0, };
+    struct ifreq ifr = {0, };
+
+    ecmd.cmd = ETHTOOL_GSET;
+
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
+    ifr.ifr_data = (void *) &ecmd;
+
+    /* Get current settings */
+    if (ioctl(nb->inet_fd, SIOCETHTOOL, &ifr) < 0) {
+	error("ioctl(0x%04x) failed for getting '%s': %s for %s", SIOCETHTOOL, "ETHTOOL_GSET", strerror(errno), ifname);
+	nb->last_error = errno;
+	return -1;
+    }
+
+    /* Disable autonegotiation */
+    ecmd.autoneg = AUTONEG_DISABLE;
+
+    ecmd.speed = speed;
+    ecmd.duplex = duplex;
+
+    /* Apply new settings */
+    ecmd.cmd = ETHTOOL_SSET;
+
+    if (ioctl(nb->inet_fd, SIOCETHTOOL, &ifr) < 0) {
+	error("ioctl(0x%04x) failed for getting '%s': %s for %s", SIOCETHTOOL, "ETHTOOL_SSET", strerror(errno), ifname);
+	return -1;
+    }
+
+    debug("Speed and duplexity updated successfully.\n");
+
+    return 0;
+}
+
 static int netif_build_ifinfo(const struct nlmsghdr *nlh, void *data)
 {
   struct netif *nb = (struct netif *) data;
@@ -951,6 +988,8 @@ static int set_ipv6_forwarding(const struct ip_setting_handler *handler, struct 
 static int get_ipv6_forwarding(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname);
 static int prep_advertised_link_modes(const struct ip_setting_handler *handler, struct netif *nb, void **context);
 static int set_advertised_link_modes(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname, void *context);
+static int prep_link_mode(const struct ip_setting_handler *handler, struct netif *nb, void **context);
+static int set_link_mode(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname, void *context);
 
 
 /* These handlers are listed in the order that they should be invoked when
@@ -1071,6 +1110,13 @@ static const struct ip_setting_handler handlers[] = {
     .ioctl_set = 0,
     .ioctl_get = 0,
   },
+  { .name = "link_mode",
+    .prep = prep_link_mode,
+    .set  = set_link_mode,
+    .get  = NULL,
+    .ioctl_set = 0,
+    .ioctl_get = 0,
+  },
   { .name = NULL, } /* Setting-up a guard */
 };
 #define HANDLER_COUNT ((sizeof(handlers)-1) / sizeof(handlers[0])) /* -1 is for the guard at the end of the array */
@@ -1184,6 +1230,34 @@ static int prep_advertised_link_modes(const struct ip_setting_handler *handler, 
     }
 
     *context = link_modes;
+
+    return 0;
+}
+
+struct link_mode_ctx {
+    unsigned long speed;
+    char duplex[10];
+    int tuple_arity;
+};
+
+static int prep_link_mode(const struct ip_setting_handler *handler, struct netif *nb, void **context)
+{
+    struct link_mode_ctx *lm_ctx = *context = malloc(sizeof(struct link_mode_ctx));
+
+    if(*context == NULL) {
+	errx(EXIT_FAILURE, "Unable to allocate memory for '%s'", handler->name);
+    }
+
+    if (erlcmd_decode_tuple_header(nb->req, &nb->req_index, &lm_ctx->tuple_arity) < 0 || lm_ctx->tuple_arity != 2)
+	errx(EXIT_FAILURE, "A tuple of {Speed, Duplex} is required for '%s'", handler->name);
+
+    if (erlcmd_decode_uint(nb->req, &nb->req_index, &lm_ctx->speed) < 0)
+	errx(EXIT_FAILURE, "Speed parameter required for '%s'", handler->name);
+
+    if (erlcmd_decode_atom(nb->req, &nb->req_index, &lm_ctx->duplex[0], sizeof(lm_ctx->duplex)) < 0)
+	errx(EXIT_FAILURE, "Duplex parameter required for '%s'", handler->name);
+
+    debug("Decoded speed = '%u', duplex = '%s' for '%s'", lm_ctx->speed, lm_ctx->duplex, handler->name);
 
     return 0;
 }
@@ -1358,6 +1432,38 @@ static int set_advertised_link_modes(const struct ip_setting_handler *handler, s
         error("Failed for setting '%s': %s", handler->name, strerror(errno));
         nb->last_error = errno;
         return -1;
+    }
+
+    return 0;
+}
+
+static int set_link_mode(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname, void *context)
+{
+    if (context == NULL) {
+	debug("Bad speed/duplexity value '%s'", handler->name);
+	nb->last_error = EINVAL;
+	return -1;
+    }
+
+    const struct link_mode_ctx *lm = (const struct link_mode_ctx *) context;
+    debug("Setting speed = '%u', duplex = '%s' for '%s'", lm->speed, lm->duplex, handler->name);
+
+    __u8 duplex = DUPLEX_FULL;
+    if(strncmp(lm->duplex, "full", sizeof(lm->duplex)) == 0) {
+	duplex = DUPLEX_FULL;
+    }
+    else if(strncmp(lm->duplex, "half", sizeof(lm->duplex)) == 0) {
+	duplex = DUPLEX_HALF;
+    }
+    else {
+	error("Bad duplexity value '%s' for '%s'", lm->duplex, handler->name);
+	nb->last_error = EINVAL;
+	return -1;
+    }
+    if (ethtool_sset_speed_duplexity_ioctl(nb, ifname, lm->speed, duplex) < 0) {
+	error("Failed for setting '%s': %s", handler->name, strerror(errno));
+	nb->last_error = errno;
+	return -1;
     }
 
     return 0;
@@ -2414,12 +2520,12 @@ static void netif_handle_set(struct netif *nb,
     // the caller can pass in maps that contain options for other code.
     handler = (struct ip_setting_handler *) find_handler(name);
 
-    debug("%s %d]: handler for '%s' = %p\r\n", __FILE__, __LINE__, name, (void *) handler);
+    debug("[%s %d]: handler for '%s' = %p\r\n", __FILE__, __LINE__, name, (void *) handler);
 
     if (handler != NULL) {
       handler->prep(handler, nb, &handler_context[handler - handlers]);
     } else {
-      debug("%s %d]: No known handler for '%s' = %p! Skipping term...\r\n", __FILE__, __LINE__, name, (void *) handler);
+      debug("[%s %d]: No known handler for '%s' = %p! Skipping term...\r\n", __FILE__, __LINE__, name, (void *) handler);
       ei_skip_term(nb->req, &nb->req_index);
     }
   }


### PR DESCRIPTION
Add support for configuring Ethernet link negotiation through:

advertised link modes bitmap configuration
enforced fixed link mode settings

Examples:
Nerves.NetworkInterface.setup("eth0", %{link_mode: {100, :half}})

Nerves.NetworkInterface.setup("eth0", %{
  advertised_link_modes: 0x3f
})