### PR TITLE
Update muontrap dependency to se-apc main and worker changes

### DIFF
--- a/lib/network_interface/worker.ex
+++ b/lib/network_interface/worker.ex
@@ -131,9 +131,32 @@ defmodule Nerves.NetworkInterface.Worker do
   def init([]) do
     Logger.warning "Start Network Interface Worker"
     executable = :code.priv_dir(:nerves_network_interface) ++ '/netif'
-    port = Port.open({:spawn_executable, to_charlist(MuonTrap.muontrap_path())},
-    [{:args, ["--", executable]}, {:packet, 2}, :use_stdio, :binary])
-    { :ok, %Nerves.NetworkInterface.Worker{port: port} }
+    muontrap_path = MuonTrap.muontrap_path()
+
+    args =
+      if muontrap_supports_option?(muontrap_path, "--passthrough-stdio") do
+        ["--passthrough-stdio", "--", executable]
+      else
+        Logger.warning("MuonTrap does not support --passthrough-stdio. Using capture-output fallback.")
+        ["--capture-output", "--capture-stderr", "--", executable]
+      end
+
+    port =
+      Port.open({:spawn_executable, to_charlist(muontrap_path)},
+        [{:args, args}, {:packet, 2}, :use_stdio, :binary]
+      )
+
+    {:ok, %Nerves.NetworkInterface.Worker{port: port}}
+  end
+
+  defp muontrap_supports_option?(muontrap_path, option) do
+    case System.cmd(to_string(muontrap_path), ["--help"], stderr_to_stdout: true) do
+      {output, _exit_code} ->
+        String.contains?(output, option)
+    end
+  rescue
+    _ ->
+      false
   end
 
   #Returns intersection of lists a and b
@@ -247,6 +270,12 @@ defmodule Nerves.NetworkInterface.Worker do
     receive do
       {_, {:data, <<?r, response::binary>>}} ->
         :erlang.binary_to_term(response)
+
+      {_, {:exit_status, status}} ->
+        {:error, {:port_exit, status}}
+
+      {_, :closed} ->
+        {:error, :port_closed}
     after
       4_000 ->
         # Not sure how this can be recovered

--- a/mix.exs
+++ b/mix.exs
@@ -43,8 +43,7 @@ defmodule Nerves.NetworkInterface.Mixfile do
      {:elixir_make, "~> 0.4", runtime: false},
      {:ex_doc, "~> 0.11", only: :dev},
      
-     ## netif doesn't seem to work with later versions of muontrap
-     {:muontrap, "~> 1.5"}
+     {:muontrap, github: "se-apc/muontrap", branch: "main"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,6 @@
   "makeup": {:hex, :makeup, "1.1.2", "9ba8837913bdf757787e71c1581c21f9d2455f4dd04cfca785c70bbfff1a76a3", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cce1566b81fbcbd21eca8ffe808f33b221f9eee2cbc7a1706fc3da9ff18e6cac"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.2", "627e84b8e8bf22e60a2579dad15067c755531fea049ae26ef1020cad58fe9578", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "41193978704763f6bbe6cc2758b84909e62984c7752b3784bd3c218bb341706b"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.0", "6f0eff9c9c489f26b69b61440bf1b238d95badae49adac77973cbacae87e3c2e", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "ea7a9307de9d1548d2a72d299058d1fd2339e3d398560a0e46c27dab4891e4d2"},
-  "muontrap": {:hex, :muontrap, "1.8.0", "3c5dab5bc91d5a16d14cd85b130ae7d35a9c469564a11ba4b2ebbcd7ccf5bc05", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "45ff36451303cbdefe1c66da3681b5aff078ee5737348f554f0017daa66284af"},
+  "muontrap": {:git, "https://github.com/se-apc/muontrap.git", "0bcb8df3f238a424655c29a743e3fe862c584f3f", [branch: "main"]},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
 }


### PR DESCRIPTION
Depend on: https://github.com/se-apc/muontrap .